### PR TITLE
Ignore a plugin if it doesn't match the input file type

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var identity = function(a) { return a }
 module.exports = function sheetify_jstransform(filename, source, options, cb) {
   var use = [].concat(options.use)
   var current = source
+
   function runTransform() {
     try {
       var useSingle = use.shift()
@@ -12,7 +13,15 @@ module.exports = function sheetify_jstransform(filename, source, options, cb) {
       }
       useSingle = [].concat(useSingle)
       var transformer = jstransformer(useSingle[0])
-      var opts = useSingle[1]
+      var matchesTransformer = transformer.inputFormats.some(function (format) {
+        return RegExp('\.' + format + '$').test(filename)
+      })
+      if (!matchesTransformer) {
+        runTransform()
+        return
+      }
+
+      var opts = useSingle[1] || {}
       var optsCb = useSingle[2] || identity
       opts = optsCb(opts, filename)
       transformer.renderAsync(current, opts, {}, function(err, result) {


### PR DESCRIPTION
I realized while trying this plugin with Stylus files, that it would also process CSS files, which obviously breaks. I solved it by not applying a plugin that doesn't match the type of the file being processed.